### PR TITLE
Reservoir control curves

### DIFF
--- a/pywr/core.py
+++ b/pywr/core.py
@@ -556,7 +556,7 @@ class ParameterDailyProfile(Parameter):
         self._values = values
 
     def value(self, index=None):
-        return self._values[index.dayofyear-1]
+        return self._values[index.datetime.dayofyear-1]
 
     @classmethod
     def from_xml(cls, xml):
@@ -1045,14 +1045,14 @@ class StorageInput(BaseInput):
         super(StorageInput, self).commit(volume)
         self.parent.commit(-volume)
 
+
 class StorageOutput(BaseOutput):
     def commit(self, volume):
         super(StorageOutput, self).commit(volume)
         self.parent.commit(volume)
 
-class Storage(with_metaclass(NodeMeta, HasDomain, Drawable, Connectable,
-                             XMLSeriaizable, _core.Storage)):
-    """A generic storage node
+class Storage(with_metaclass(NodeMeta, HasDomain, Drawable, Connectable, XMLSeriaizable, _core.Storage)):
+    """A generic storage Node
 
     The storage node contains an input node (or nodes) and an output node (or
     nodes).

--- a/pywr/core.py
+++ b/pywr/core.py
@@ -1045,7 +1045,6 @@ class StorageInput(BaseInput):
         super(StorageInput, self).commit(volume)
         self.parent.commit(-volume)
 
-
 class StorageOutput(BaseOutput):
     def commit(self, volume):
         super(StorageOutput, self).commit(volume)

--- a/pywr/domains/river.py
+++ b/pywr/domains/river.py
@@ -68,7 +68,7 @@ class Reservoir(RiverDomainMixin, Storage):
                 as a percentage of fill, for the given timestep.
             above_curve_cost - The cost to apply when the reservoir is above its curve.
         """
-        self.control_curve = kwargs.pop('control_curve', None)
+        self.control_curve = pop_kwarg_parameter(kwargs, 'control_curve', None)
         self.above_curve_cost = kwargs.pop('above_curve_cost', 0.0)
         super(Reservoir, self).__init__(*args, **kwargs)
 
@@ -78,9 +78,9 @@ class Reservoir(RiverDomainMixin, Storage):
             return super(Reservoir, self).get_cost(ts)
 
         if isinstance(self.control_curve, Parameter):
-            control_curve = self.control_curve.value(ts)
+            control_curve = self.control_curve.value(ts)/100.0
         else:
-            control_curve = self.control_curve
+            control_curve = self.control_curve/100.0
 
         # If level above control curve then return above_curve_cost
         if self.current_pc >= control_curve:

--- a/pywr/domains/river.py
+++ b/pywr/domains/river.py
@@ -51,9 +51,37 @@ class Catchment(RiverDomainMixin, Input):
             return
         super(Catchment, self).__setattr__(name, value)
 
+
 class Reservoir(RiverDomainMixin, Storage):
+    """A reservoir node with control curve.
+
+    The Reservoir is a subclass of Storage with additional functionality to provide a
+    simple control curve. The Reservoir has above_curve_cost when it is above its curve
+    and the user defined cost when it is below. Typically the costs are negative
+    to represent a benefit of filling the reservoir when it is below its curve.
+    """
     def __init__(self, *args, **kwargs):
+        """
+
+        Keywords:
+            control_curve - A Parameter object that can return the control curve position,
+                as a percentage of fill, for the given timestep.
+            above_curve_cost - The cost to apply when the reservoir is above its curve.
+        """
+        self.control_curve = kwargs.pop('control_curve', None)
+        self.above_curve_cost = kwargs.pop('above_curve_cost', 0.0)
         super(Reservoir, self).__init__(*args, **kwargs)
+
+    def get_cost(self, ts):
+        # If no control curve given behaves like a normal Storage
+        if self.control_curve is None:
+            return super(Reservoir, self).get_cost(ts)
+
+        control_curve = self.control_curve.value(ts)/100.0
+        # If level above control curve then return above_curve_cost
+        if self.current_pc >= control_curve:
+            return self.above_curve_cost
+        return super(Reservoir, self).get_cost(ts)
 
 
 class River(RiverDomainMixin, Link):

--- a/pywr/domains/river.py
+++ b/pywr/domains/river.py
@@ -78,9 +78,9 @@ class Reservoir(RiverDomainMixin, Storage):
             return super(Reservoir, self).get_cost(ts)
 
         if isinstance(self.control_curve, Parameter):
-            control_curve = self.control_curve.value(ts)/100.0
+            control_curve = self.control_curve.value(ts)
         else:
-            control_curve = self.control_curve/100.0
+            control_curve = self.control_curve
         # If level above control curve then return above_curve_cost
         if self.current_pc >= control_curve:
             return self.above_curve_cost

--- a/pywr/domains/river.py
+++ b/pywr/domains/river.py
@@ -68,7 +68,7 @@ class Reservoir(RiverDomainMixin, Storage):
                 as a percentage of fill, for the given timestep.
             above_curve_cost - The cost to apply when the reservoir is above its curve.
         """
-        self.control_curve = pop_kwarg_parameter(kwargs, 'control_curve', None)
+        self.control_curve = kwargs.pop('control_curve', None)
         self.above_curve_cost = kwargs.pop('above_curve_cost', 0.0)
         super(Reservoir, self).__init__(*args, **kwargs)
 
@@ -81,6 +81,7 @@ class Reservoir(RiverDomainMixin, Storage):
             control_curve = self.control_curve.value(ts)
         else:
             control_curve = self.control_curve
+
         # If level above control curve then return above_curve_cost
         if self.current_pc >= control_curve:
             return self.above_curve_cost

--- a/pywr/domains/river.py
+++ b/pywr/domains/river.py
@@ -1,5 +1,5 @@
 
-from ..core import Node, Domain, Input, Output, Link, Storage, PiecewiseLink, ParameterFunction, pop_kwarg_parameter
+from ..core import Node, Domain, Input, Output, Link, Storage, PiecewiseLink, Parameter, ParameterFunction, pop_kwarg_parameter
 
 DEFAULT_RIVER_DOMAIN = Domain(name='river', color='#33CCFF')
 
@@ -68,7 +68,7 @@ class Reservoir(RiverDomainMixin, Storage):
                 as a percentage of fill, for the given timestep.
             above_curve_cost - The cost to apply when the reservoir is above its curve.
         """
-        self.control_curve = kwargs.pop('control_curve', None)
+        self.control_curve = pop_kwarg_parameter(kwargs, 'control_curve', None)
         self.above_curve_cost = kwargs.pop('above_curve_cost', 0.0)
         super(Reservoir, self).__init__(*args, **kwargs)
 
@@ -77,7 +77,10 @@ class Reservoir(RiverDomainMixin, Storage):
         if self.control_curve is None:
             return super(Reservoir, self).get_cost(ts)
 
-        control_curve = self.control_curve.value(ts)/100.0
+        if isinstance(self.control_curve, Parameter):
+            control_curve = self.control_curve.value(ts)/100.0
+        else:
+            control_curve = self.control_curve/100.0
         # If level above control curve then return above_curve_cost
         if self.current_pc >= control_curve:
             return self.above_curve_cost

--- a/pywr/domains/river.py
+++ b/pywr/domains/river.py
@@ -78,10 +78,9 @@ class Reservoir(RiverDomainMixin, Storage):
             return super(Reservoir, self).get_cost(ts)
 
         if isinstance(self.control_curve, Parameter):
-            control_curve = self.control_curve.value(ts)/100.0
+            control_curve = self.control_curve.value(ts)
         else:
-            control_curve = self.control_curve/100.0
-
+            control_curve = self.control_curve
         # If level above control curve then return above_curve_cost
         if self.current_pc >= control_curve:
             return self.above_curve_cost

--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -179,7 +179,7 @@ cdef class CythonGLPKSolver:
         # update route properties
         for col, route in enumerate(routes):
             cost = 0.0
-            for node in route:
+            for node in route[:-1]:
                 cost += node.get_cost(timestep)
             glp_set_obj_coef(self.prob, self.idx_col_routes+col, cost)
 

--- a/tests/test_river.py
+++ b/tests/test_river.py
@@ -74,7 +74,7 @@ def test_control_curve(solver):
     lnk.connect(demand)
 
     reservoir = river.Reservoir(model, name="Reservoir", max_volume=10, cost=-20,
-                                control_curve=80, volume=10,
+                                control_curve=0.8, volume=10,
                                 input_max_flow=2, output_max_flow=2)
     lnk.connect(reservoir)
     reservoir.connect(demand)


### PR DESCRIPTION
Initial attempt at addressing #10 

The control curve is implemented on the `Reservoir` by overloading the `get_cost` method. This alters the cost when the reservoir fill percentage is equal to or above a user defined threshold (`above_curve_cost`). When below the curve the usual `cost` parameter is used.

There is a test of this as well.