### PR TITLE
Removed overloaded after on Storage. 

### DIFF
--- a/pywr/core.py
+++ b/pywr/core.py
@@ -1164,11 +1164,7 @@ class Storage(with_metaclass(NodeMeta, HasDomain, Drawable, Connectable,
     def commit(self, value):
         super(Storage, self).commit(value)
         self._change += value
-
-    def after(self, timestep):
-        super(Storage, self).after(timestep)
-        if self.recorder is not None:
-            self.recorder.commit(timestep, self._change)
+        
 
 class PiecewiseLink(Node):
     """ An extension of Nodes that represents a non-linear Link with a piece wise cost function.

--- a/pywr/core.py
+++ b/pywr/core.py
@@ -1084,7 +1084,6 @@ class Storage(with_metaclass(NodeMeta, HasDomain, Drawable, Connectable,
             # set name, avoiding issues with multiple inheritance
             self.__name = None
             self.name = name
-        self._domain = kwargs.pop('domain', None)
         self.parent = kwargs.pop('parent', None)
         # TODO fix this default hack
         self.recorder = kwargs.pop('recorder', _core.NumpyArrayRecorder(len(model.timestepper)))

--- a/pywr/core.py
+++ b/pywr/core.py
@@ -677,6 +677,7 @@ class Drawable(object):
     def __init__(self, *args, **kwargs):
         self.position = kwargs.pop('position', None)
         self.color = kwargs.pop('color', 'black')
+        self.visible = kwargs.pop('visible', True)
         super(Drawable, self).__init__(*args, **kwargs)
 
 
@@ -838,7 +839,6 @@ class BaseNode(with_metaclass(NodeMeta, _core.Node)):
         model.dirty = True
 
         self.color = 'black'
-        self.visible = kwargs.pop('visible', True)
         self.parent = kwargs.pop('parent', None)
         # TODO fix this default hack
         self.recorder = kwargs.pop('recorder', _core.NumpyArrayRecorder(len(model.timestepper)))
@@ -1112,6 +1112,7 @@ class Storage(with_metaclass(NodeMeta, HasDomain, Drawable, Connectable,
             elif key.startswith('output_'):
                 output_kwargs[key.replace('output_', '')] = kwargs.pop(key)
         '''
+        super(Storage, self).__init__(self, *args, **kwargs)
 
     def iter_slots(self, slot_name=None, is_connector=True):
         if is_connector:
@@ -1164,7 +1165,7 @@ class Storage(with_metaclass(NodeMeta, HasDomain, Drawable, Connectable,
     def commit(self, value):
         super(Storage, self).commit(value)
         self._change += value
-        
+
 
 class PiecewiseLink(Node):
     """ An extension of Nodes that represents a non-linear Link with a piece wise cost function.

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -365,7 +365,7 @@ def test_new_storage(solver):
     model.run()
 
     assert(supply1.recorder.data == [45])
-    assert(splitter.recorder.data == [-5])
+    assert(splitter.recorder.data == [0])  # New volume is zero
     assert(demand1.recorder.data == [20])
     assert(demand2.recorder.data == [30])
 


### PR DESCRIPTION
Storage should record the current volume, not the change (which is default behaviour for _core.Storage).