### PR TITLE
Cythonize storage

### DIFF
--- a/pywr/_core.pxd
+++ b/pywr/_core.pxd
@@ -78,6 +78,9 @@ cdef class Node(AbstractNode):
     cpdef get_conversion_factor(self)
     cdef set_parameters(self, Timestep ts, int[:] scenario_indices=*)
 
+cdef class BaseInput(Node):
+    cdef object _licenses
+
 cdef class Storage(AbstractNode):
     cdef public double[:] _volume
     cdef double _initial_volume

--- a/pywr/_core.pxd
+++ b/pywr/_core.pxd
@@ -40,52 +40,51 @@ cdef class Recorder:
     cpdef int commit(self, Timestep ts, int scenario_index, double value) except -1
     cpdef int commit_all(self, Timestep ts, double[:] value) except -1
 
-cdef class Node:
+cdef class Domain:
+    cdef object name
+
+cdef class AbstractNode:
     cdef double[:] _prev_flow
     cdef double[:] _flow
+    cdef double _cost
+    cdef Recorder _recorder
+    cdef Domain _domain
+    cdef AbstractNode _parent
+    cdef object _model
+    cdef object _name
+
+    cdef Parameter _cost_param
+    cpdef get_cost(self, Timestep ts, int[:] scenario_indices=*)
+
+    cpdef setup(self, model)
+    cpdef reset(self)
+    cpdef before(self, Timestep ts)
+    cpdef commit(self, int scenario_index, double value)
+    cpdef commit_all(self, double[:] value)
+    cpdef after(self, Timestep ts)
+    cpdef check(self,)
+
+cdef class Node(AbstractNode):
     cdef double _min_flow
     cdef double _max_flow
-    cdef double _cost
     cdef double _conversion_factor
     cdef object _min_flow_param
     cdef Parameter _max_flow_param
-    cdef Parameter _cost_param
+
     cdef Parameter _conversion_factor_param
-    cdef Recorder _recorder
 
     cpdef get_min_flow(self, Timestep ts, int[:] scenario_indices=*)
     cpdef get_max_flow(self, Timestep ts, int[:] scenario_indices=*)
-    cpdef get_cost(self, Timestep ts, int[:] scenario_indices=*)
     cpdef get_conversion_factor(self)
     cdef set_parameters(self, Timestep ts, int[:] scenario_indices=*)
 
-    cpdef setup(self, model)
-    cpdef reset(self)
-    cpdef before(self, Timestep ts)
-    cpdef commit(self, int scenario_index, double value)
-    cpdef commit_all(self, double[:] value)
-    cpdef after(self, Timestep ts)
-
-cdef class Storage:
-    cdef double[:] _flow
+cdef class Storage(AbstractNode):
     cdef public double[:] _volume
-
     cdef double _initial_volume
     cdef double _min_volume
     cdef double _max_volume
-    cdef double _cost
     cdef Parameter _min_volume_param
     cdef Parameter _max_volume_param
-    cdef Parameter _cost_param
-    cdef Recorder _recorder
 
     cpdef get_min_volume(self, Timestep ts, int[:] scenario_indices=*)
     cpdef get_max_volume(self, Timestep ts, int[:] scenario_indices=*)
-    cpdef get_cost(self, Timestep ts, int[:] scenario_indices=*)
-
-    cpdef setup(self, model)
-    cpdef reset(self)
-    cpdef before(self, Timestep ts)
-    cpdef commit(self, int scenario_index, double value)
-    cpdef commit_all(self, double[:] value)
-    cpdef after(self, Timestep ts)

--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -449,6 +449,40 @@ cdef class Node(AbstractNode):
         if self._recorder is not None:
             self._recorder.commit_all(ts, self._flow)
 
+cdef class BaseLink(Node):
+    pass
+
+
+cdef class BaseInput(Node):
+    def __init__(self, *args, **kwargs):
+        self.licenses = None
+        super(BaseInput, self).__init__(*args, **kwargs)
+
+    cpdef get_max_flow(self, Timestep timestep, int[:] scenario_indices=None):
+        """ Calculate maximum flow including licenses """
+        max_flow = Node.get_max_flow(self, timestep, scenario_indices)
+        if self.licenses is not None:
+            # TODO make licences Scenario aware
+            if len(scenario_indices) > 0:
+                import warnings
+                warnings.warn("Licences are not scenario aware!")
+            max_flow = min(max_flow, self.licenses.available(timestep))
+        return max_flow
+
+    cpdef reset(self, ):
+        if self.licenses is not None:
+            self.licenses.reset()
+        Node.reset(self)
+
+    cpdef commit(self, int scenario_index, double value):
+        if self.licenses is not None:
+            self.licenses.commit(scenario_index, value)
+        Node.commit(self, scenario_index, value)
+
+
+cdef class BaseOutput(Node):
+    pass
+
 cdef class Storage(AbstractNode):
     def __cinit__(self, ):
         self._initial_volume = 0.0

--- a/pywr/core.py
+++ b/pywr/core.py
@@ -1172,14 +1172,6 @@ class Storage(with_metaclass(NodeMeta, HasDomain, Drawable, Connectable, XMLSeri
     def check(self):
         pass  # TODO
 
-    def before(self, timestep):
-        super(Storage, self).before(timestep)
-        self._change = 0.0
-
-    def commit(self, scenario_index, value):
-        super(Storage, self).commit(scenario_index, value)
-        self._change += value
-
 
 class PiecewiseLink(Node):
     """ An extension of Nodes that represents a non-linear Link with a piece wise cost function.

--- a/pywr/core.py
+++ b/pywr/core.py
@@ -7,8 +7,9 @@ from pywr import _core
 
 # Cython objects availble in the core namespace
 from pywr._core import ParameterConstantScenario, ParameterArrayIndexed, \
-    ParameterArrayIndexedScenarioMonthlyFactors
-from pywr._core import Node as BaseNode, BaseInput, BaseLink, BaseOutput
+    ParameterArrayIndexedScenarioMonthlyFactors, BaseInput, BaseLink, BaseOutput, \
+    StorageInput, StorageOutput
+from pywr._core import Node as BaseNode
 import os
 from IPython.core.magic_arguments import kwds
 import networkx as nx
@@ -961,23 +962,6 @@ class Blender(Link):
 
         self.properties['ratio'] = pop_kwarg_parameter(kwargs, 'ratio', 0.5)
 
-class StorageInput(BaseInput):
-    def commit(self, scenario_index, volume):
-        super(StorageInput, self).commit(scenario_index, volume)
-        self.parent.commit(scenario_index, -volume)
-
-    def get_cost(self, ts, scenario_indices):
-        # Return negative of parent cost
-        return -self.parent.get_cost(ts, scenario_indices)
-
-class StorageOutput(BaseOutput):
-    def commit(self, scenario_index, volume):
-        super(StorageOutput, self).commit(scenario_index, volume)
-        self.parent.commit(scenario_index, volume)
-
-    def get_cost(self, ts, scenario_indices):
-        # Return parent cost
-        return self.parent.get_cost(ts, scenario_indices)
 
 class Storage(with_metaclass(NodeMeta, Drawable, Connectable, XMLSeriaizable, _core.Storage)):
     """A generic storage Node

--- a/pywr/core.py
+++ b/pywr/core.py
@@ -8,7 +8,7 @@ from pywr import _core
 # Cython objects availble in the core namespace
 from pywr._core import ParameterConstantScenario, ParameterArrayIndexed, \
     ParameterArrayIndexedScenarioMonthlyFactors
-from pywr._core import Node as BaseNode
+from pywr._core import Node as BaseNode, BaseInput, BaseLink, BaseOutput
 import os
 from IPython.core.magic_arguments import kwds
 import networkx as nx
@@ -858,41 +858,6 @@ class Node(with_metaclass(NodeMeta, Drawable, Connectable, XMLSeriaizable, BaseN
         Raises an exception if the node is invalid
         """
         pass
-
-
-class BaseLink(BaseNode):
-    pass
-
-
-class BaseInput(BaseNode):
-    def __init__(self, *args, **kwargs):
-        self.licenses = None
-        super(BaseInput, self).__init__(*args, **kwargs)
-
-    def get_max_flow(self, timestep, scenario_indices):
-        """ Calculate maximum flow including licenses """
-        max_flow = super(BaseInput, self).get_max_flow(timestep, scenario_indices)
-        if self.licenses is not None:
-            # TODO make licences Scenario aware
-            if len(scenario_indices) > 0:
-                import warnings
-                warnings.warn("Licences are not scenario aware!")
-            max_flow = min(max_flow, self.licenses.available(timestep))
-        return max_flow
-
-    def reset(self, ):
-        if self.licenses is not None:
-            self.licenses.reset()
-        super(BaseInput, self).reset()
-
-    def commit(self, scenario_index, value):
-        if self.licenses is not None:
-            self.licenses.commit(scenario_index, value)
-        super(BaseInput, self).commit(scenario_index, value)
-
-
-class BaseOutput(BaseNode):
-    pass
 
 
 class Input(Node, BaseInput):

--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -1,7 +1,7 @@
 # cython: profile=False
 from libc.stdlib cimport malloc, free
 
-from pywr.core import BaseInput, BaseOutput, BaseLink
+from pywr._core import BaseInput, BaseOutput, BaseLink
 from pywr._core cimport *
 
 include "glpk.pxi"

--- a/pywr/solvers/cython_lpsolve.pyx
+++ b/pywr/solvers/cython_lpsolve.pyx
@@ -2,7 +2,7 @@
 from libc.float cimport DBL_MAX
 from libc.stdlib cimport malloc, free
 
-from pywr.core import BaseInput, BaseOutput, BaseLink
+from pywr._core import BaseInput, BaseOutput, BaseLink
 from pywr._core cimport *
 
 cdef extern from "lpsolve/lp_lib.h":

--- a/tests/test_analytical.py
+++ b/tests/test_analytical.py
@@ -115,20 +115,23 @@ def two_domain_linear_model(request, solver):
     power_demand = 12  # GWh/d
     power_benefit = 10.0  # £/GWh
 
+    river_domain = pywr.core.Domain('river')
+    grid_domain = pywr.core.Domain('grid')
+
     model = pywr.core.Model(solver=solver)
     # Create river network
-    river_inpt = pywr.core.Input(model, name="Catchment", max_flow=river_flow, domain='river')
-    river_lnk = pywr.core.Link(model, name="Reach", domain='river')
+    river_inpt = pywr.core.Input(model, name="Catchment", max_flow=river_flow, domain=river_domain)
+    river_lnk = pywr.core.Link(model, name="Reach", domain=river_domain)
     river_inpt.connect(river_lnk)
-    river_otpt = pywr.core.Output(model, name="Abstraction", domain='river', cost=0.0)
+    river_otpt = pywr.core.Output(model, name="Abstraction", domain=river_domain, cost=0.0)
     river_lnk.connect(river_otpt)
     # Create grid network
-    grid_inpt = pywr.core.Input(model, name="Power Plant", max_flow=power_plant_cap, domain='grid',
+    grid_inpt = pywr.core.Input(model, name="Power Plant", max_flow=power_plant_cap, domain=grid_domain,
                                                conversion_factor=1/power_plant_flow_req)
-    grid_lnk = pywr.core.Link(model, name="Transmission", cost=1.0, domain='grid')
+    grid_lnk = pywr.core.Link(model, name="Transmission", cost=1.0, domain=grid_domain)
     grid_inpt.connect(grid_lnk)
     grid_otpt = pywr.core.Output(model, name="Substation", max_flow=power_demand,
-                                 cost=-power_benefit, domain='grid')
+                                 cost=-power_benefit, domain=grid_domain)
     grid_lnk.connect(grid_otpt)
     # Connect grid to river
     river_otpt.connect(grid_inpt)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -160,7 +160,7 @@ def test_dirty_model(solver):
 def test_shorthand_property(solver):
     # test shorthand assignment of constant properties
     model = Model(solver=solver)
-    node = BaseNode(model, 'node')
+    node = Node(model, 'node')
     for attr in ('min_flow', 'max_flow', 'cost', 'conversion_factor'):
         # should except int, float or Paramter
         setattr(node, attr, 123)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -420,7 +420,6 @@ def test_run_until_date(solver):
     model = load_model('simple1.xml', solver=solver)
 
     # run until date
-    model.reset()
     timestep = model.run(until_date=pandas.to_datetime('2015-01-20'))
     assert(timestep.index == 20)
 


### PR DESCRIPTION
More work on cythonizing things. The `Base*`, `StorageInput` and `StorageOutput` are all now in Cython space. It's given a nice speed-up on the London model (~25%)

More can be done if the licence object is cythonized. I guess we could do with some continuous benchmarking.