### PR TITLE
Added NumpyArrayStorageRecorder

### DIFF
--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -130,6 +130,10 @@ cdef class AbstractNode:
             self._name = name
             self.model.node[name] = self
 
+    property recorders:
+        def __get__(self):
+            return self._recorders
+
     property model:
         """The recorder for the node, e.g. a NumpyArrayRecorder
         """

--- a/pywr/_recorders.pxd
+++ b/pywr/_recorders.pxd
@@ -1,6 +1,6 @@
 cdef class Recorder
 
-from _core cimport Timestep, Node, Storage
+from _core cimport Timestep, AbstractNode, Storage
 
 cdef class Recorder:
     cdef object _model
@@ -10,7 +10,7 @@ cdef class Recorder:
     cpdef finish(self)
 
 cdef class NodeRecorder(Recorder):
-    cdef Node _node
+    cdef AbstractNode _node
 
 
 cdef class StorageRecorder(Recorder):

--- a/pywr/_recorders.pxd
+++ b/pywr/_recorders.pxd
@@ -18,3 +18,6 @@ cdef class StorageRecorder(Recorder):
 
 cdef class NumpyArrayNodeRecorder(NodeRecorder):
     cdef double[:, :] _data
+
+cdef class NumpyArrayStorageRecorder(StorageRecorder):
+    cdef double[:, :] _data

--- a/pywr/_recorders.pyx
+++ b/pywr/_recorders.pyx
@@ -56,3 +56,24 @@ cdef class NumpyArrayNodeRecorder(NodeRecorder):
     property data:
         def __get__(self, ):
             return np.array(self._data)
+
+
+cdef class NumpyArrayStorageRecorder(StorageRecorder):
+    cpdef setup(self):
+        cdef int ncomb = len(self._model.scenarios.combinations)
+        cdef int nts = len(self._model.timestepper)
+        self._data = np.zeros((nts, ncomb))
+
+    cpdef reset(self):
+        self._data[:, :] = 0.0
+
+    cpdef int save(self) except -1:
+        cdef int i
+        cdef Timestep ts = self._model.timestepper.current
+        for i in range(self._data.shape[1]):
+            self._data[ts._index,i] = self._node._volume[i]
+        return 0
+
+    property data:
+        def __get__(self, ):
+            return np.array(self._data)

--- a/pywr/_recorders.pyx
+++ b/pywr/_recorders.pyx
@@ -24,7 +24,7 @@ cdef class Recorder:
 
 
 cdef class NodeRecorder(Recorder):
-    def __init__(self, model, Node node):
+    def __init__(self, model, AbstractNode node):
         Recorder.__init__(self, model)
         self._node = node
         node._recorders.append(self)

--- a/pywr/recorders.py
+++ b/pywr/recorders.py
@@ -1,4 +1,4 @@
-from pywr._recorders import Recorder, NodeRecorder, StorageRecorder, NumpyArrayNodeRecorder
+from pywr._recorders import Recorder, NodeRecorder, StorageRecorder, NumpyArrayNodeRecorder, NumpyArrayStorageRecorder
 
 
 class CSVRecorder(Recorder):


### PR DESCRIPTION
Seems an obvious missing recorder. 

Also made the `_recorders` property on `AbstractNode` read-only accessible from Python, and made the `NodeRecorder` object accept `AbstractNode` instead of `Node`.