### PR TITLE
Show build errors when no solvers are built

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,9 @@ before_install:
     - conda update --yes conda
 
     # dependencies
-    - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy scipy matplotlib pytest dateutil pandas statsmodels networkx xlrd cython six ipython pytables
+    - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy scipy matplotlib dateutil pandas statsmodels networkx xlrd cython six ipython pytables
+    # pytest from conda is too old, see https://github.com/pytest-dev/pytest/issues/995
+    - pip install pytest==2.8.5
 
     # system libraries
     - sudo apt-get install -qq libgmp3-dev libglpk-dev glpk liblpsolve55-dev lp-solve

--- a/setup.py
+++ b/setup.py
@@ -67,65 +67,6 @@ if 'lpsolve' in optional:
                   libraries=['lpsolve55'],),
     )
 
-# Optional extension code from Bob Ippolito's simplejson project
-# https://github.com/simplejson/simplejson
-
-if sys.platform == 'win32' and sys.version_info > (2, 6):
-    # 2.6's distutils.msvc9compiler can raise an IOError when failing to
-    # find the compiler
-    # It can also raise ValueError http://bugs.python.org/issue7511
-    ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError,
-                  IOError, ValueError)
-else:
-    ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)
-
-class BuildFailed(Exception):
-    def __init__(self, exc_info):
-        self.exc_info = exc_info
-
-
-class ve_build_ext(build_ext):
-    # This class allows C extension building to fail.
-
-    def run(self):
-        try:
-            build_ext.run(self)
-        except DistutilsPlatformError:
-            raise BuildFailed(e)
-
-    def build_extension(self, ext):
-        try:
-            build_ext.build_extension(self, ext)
-        except ext_errors:
-            raise BuildFailed(sys.exc_info())
-
-setup_kwargs['cmdclass'] = {}
-
-# attempt to build the cython solver extensions
-success = []
-failure = []
-for extension in extensions_optional:
-    setup_kwargs['ext_modules'] = cythonize([extension], compiler_directives=compiler_directives)
-    setup_kwargs['cmdclass']['build_ext'] = ve_build_ext
-    try:
-        setup(**setup_kwargs)
-    except BuildFailed as e:
-        failure.append((extension, e))
-    else:
-        success.append(extension)
-
-if not success:
-    for ext, excep in failure:
-        print('Build failed for extension: {}'.format(ext.name))
-        import traceback
-        traceback.print_exception(*excep.exc_info)
-    raise BuildFailed('None of the solvers managed to build')
-
 # build the core extension(s)
-setup_kwargs['ext_modules'] = cythonize(extensions, compiler_directives=compiler_directives)
-del(setup_kwargs['cmdclass']['build_ext'])
+setup_kwargs['ext_modules'] = cythonize(extensions + extensions_optional, compiler_directives=compiler_directives)
 setup(**setup_kwargs)
-
-print('\nSuccessfully built pywr with the following extensions:')
-for extension in success:
-    print('  * {}'.format(extension.name))

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python
 
-from setuptools import setup
-from distutils.extension import Extension
+try:
+    from setuptools import setup
+    from setuptools import Extension
+    print('Using setuptools for setup!')
+except ImportError:
+    from distutils.core import setup
+    from distutils.extension import Extension
+    print('Using distutils for setup!')
 from distutils.errors import CCompilerError, DistutilsExecError, \
     DistutilsPlatformError
 from Cython.Distutils import build_ext


### PR DESCRIPTION
Some changes to `setup.py`:
- moved to setuptools.setup rather than distutils, and
- display traceback for the solver builds if none of them are successful.