### PR TITLE
Initial attempt at adding solver statistics to the GLPK solver.

### DIFF
--- a/pywr/solvers/__init__.py
+++ b/pywr/solvers/__init__.py
@@ -56,6 +56,10 @@ else:
         def solve(self, model):
             return self._cy_solver.solve(model)
 
+        @property
+        def stats(self):
+            return self._cy_solver.stats
+
 
 try:
     from .cython_lpsolve import CythonLPSolveSolver as cy_CythonLPSolveSolver


### PR DESCRIPTION
This method uses a dictionary on the solvers to accumulate timings on different parts of the solve. Times are summed with previous totals to accumulate the total time if the solver is used multiple times (i.e. through a series of timesteps).

Opinions please.