### PR TITLE
Initialise AbstractNode._flow with 0D array in __init__. Fixes #82.

### DIFF
--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -90,6 +90,8 @@ cdef class AbstractNode:
         self._domain = kwargs.pop('domain', None)
         self._recorders = []
 
+        self._flow = np.empty([0,], np.float64)
+
     property cost:
         """The cost per unit flow via the node
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -174,3 +174,11 @@ def test_shorthand_property(solver):
         with pytest.raises(TypeError):
             setattr(node, attr, '123')
             setattr(node, attr, None)
+
+
+def test_reset_before_run(solver):
+    # See issue #82. Previously this would raise:
+    #    AttributeError: Memoryview is not initialized
+    model = Model(solver=solver)
+    node = Node(model, 'node')
+    model.reset()


### PR DESCRIPTION
This PR fixes #82 by initialising _flow in `AbstractNode.__init__`. Otherwise, if `Node.reset` is called before `Model.run`, it attempts to access an uninitialised variable. Added a test that triggers the bug too.