### PR TITLE
Refactor of Model.nodes using NodeIterator class

### DIFF
--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -82,8 +82,6 @@ cdef class Domain:
 cdef class AbstractNode:
     def __init__(self, model, name, **kwargs):
         self._model = model
-        model.graph.add_node(self)
-        model.dirty = True
         self.name = name
 
         self._parent = kwargs.pop('parent', None)
@@ -121,16 +119,10 @@ cdef class AbstractNode:
 
         def __set__(self, name):
             # check for name collision
-            if name in self.model.node:
+            if name in self.model.nodes.keys():
                 raise ValueError('A node with the name "{}" already exists.'.format(name))
-            # remove old name
-            try:
-                del(self.model.node[self._name])
-            except KeyError:
-                pass
             # apply new name
             self._name = name
-            self.model.node[name] = self
 
     property recorders:
         def __get__(self):

--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -57,7 +57,7 @@ cdef class CythonGLPKSolver:
 
         non_storages = []
         storages = []
-        for some_node in model.nodes():
+        for some_node in model.graph.nodes():
             if isinstance(some_node, (BaseInput, BaseLink, BaseOutput)):
                 non_storages.append(some_node)
             elif isinstance(some_node, Storage):

--- a/pywr/solvers/cython_lpsolve.pyx
+++ b/pywr/solvers/cython_lpsolve.pyx
@@ -154,7 +154,7 @@ cdef class CythonLPSolveSolver:
         supplys = []
         demands = []
         storages = []
-        for some_node in model.nodes():
+        for some_node in model.graph.nodes():
             if isinstance(some_node, (BaseInput, BaseLink)):
                 supplys.append(some_node)
             if isinstance(some_node, BaseOutput):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -9,6 +9,11 @@ import datetime
 import pytest
 
 @pytest.fixture()
+def model(request, solver):
+    model = Model(solver=solver)
+    return model
+
+@pytest.fixture()
 def simple_linear_model(request, solver):
     """
     Make a simple model with a single Input and Output.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,6 +4,7 @@
 from __future__ import print_function
 
 import pytest
+from fixtures import *
 from pywr._core import Timestep
 
 from pywr.core import *
@@ -35,11 +36,31 @@ def test_names(solver):
     # attempt name collision (via new)
     with pytest.raises(ValueError):
         node3 = Input(model, name='C')
-    assert(len(model.node) == 2)
+    assert(len(model.node) == 2)  # node3 not added to graph
 
     # attempt to create a node without a name
     with pytest.raises(TypeError):
         node4 = Input(model)
+
+
+def test_model_nodes(model):
+    """Test Model.nodes API"""
+    node = Input(model, 'test')
+
+    # test node by index
+    assert(model.nodes['test'] is node)
+
+    with pytest.raises(KeyError):
+        model.nodes['invalid']
+
+    # test node iterator
+    all_nodes = [node for node in model.nodes]
+    assert(all_nodes == [node])
+
+    # support for item deletion
+    del(model.nodes['test'])
+    all_nodes = [node for node in model.nodes]
+    assert(all_nodes == [])
 
 
 def test_slots_connect_disconnect(solver):


### PR DESCRIPTION
This PR resolves issue #48 (renaming Storage nodes doesn't rename the children) by replacing `Model.nodes` with an instance of `NodeIterator`. The API is unchanged. It also resolves the issue identified in #85, where nodes that raise an exception in their `__init__` were still added to the graph.